### PR TITLE
Add Virtual Beacon and Bluetooth LE Radar to the list of tools

### DIFF
--- a/examples/index.md
+++ b/examples/index.md
@@ -10,6 +10,8 @@ Examples of how the AltBeacon spec is implemented in the real world. This includ
 - [AltBeacon Locate](https://play.google.com/store/apps/details?id=com.radiusnetworks.locate) Android Utility for detecting AltBeacons
 - [QuickBeacon](https://play.google.com/store/apps/details?id=com.radiusnetworks.quickbeacon) Android Utility for transmitting as an AltBeacon
 - [Beacon Simulator](https://play.google.com/store/apps/details?id=net.alea.beaconsimulator) Android Utility for transmitting as an AltBeacon or other beacon formats, with management of different configurations
+- [VirtualBeacon](https://play.google.com/store/apps/details?id=com.fruitmobile.app.vbeacon.trial) Android Utility for transmitting as an AltBeacon or other beacons
+- [Bluetooth LE Radar](https://play.google.com/store/apps/details?id=com.fruitmobile.bluetoothradar) Android Utility for detecting Altbeacon or other ble devices
 
 ## Code
 


### PR DESCRIPTION
Adding to tools, Android apps Virtual beacon and Bluetooth LE Radar. 
Virtual beacon can be used to transmit as an AltBeacon from an Android device supporting peripheral mode.
Bluetooth LE Radar can be used to detect Alt beacon or other beacons